### PR TITLE
feat: copilot-compose.sh のサブコマンドにデフォルト引数を追加

### DIFF
--- a/scripts/copilot-compose.sh
+++ b/scripts/copilot-compose.sh
@@ -18,4 +18,27 @@ if gh auth status >/dev/null 2>&1; then
     fi
 fi
 
-exec docker compose -f "${repo_root}/compose.yaml" "$@"
+cmd="${1:-}"
+shift || true
+
+case "${cmd}" in
+    build)
+        exec docker compose -f "${repo_root}/compose.yaml" build "$@"
+        ;;
+    up)
+        exec docker compose -f "${repo_root}/compose.yaml" up -d "$@"
+        ;;
+    exec)
+        exec docker compose -f "${repo_root}/compose.yaml" exec workspace bash "$@"
+        ;;
+    down)
+        exec docker compose -f "${repo_root}/compose.yaml" down "$@"
+        ;;
+    "")
+        echo "使い方: $(basename "$0") {build|up|exec|down} [追加オプション...]" >&2
+        exit 1
+        ;;
+    *)
+        exec docker compose -f "${repo_root}/compose.yaml" "${cmd}" "$@"
+        ;;
+esac


### PR DESCRIPTION
## 概要

`copilot-compose.sh` に渡すサブコマンドのデフォルト引数を自動補完するようにしました。

## 変更内容

| コマンド | 実行される内容 |
|---|---|
| `./scripts/copilot-compose.sh build` | `docker compose build` |
| `./scripts/copilot-compose.sh up` | `docker compose up -d`（`-d` を自動付与） |
| `./scripts/copilot-compose.sh exec` | `docker compose exec workspace bash`（サービス名・シェルを自動付与） |
| `./scripts/copilot-compose.sh down` | `docker compose down` |

上記以外のサブコマンドはこれまで通りそのまま `docker compose` に渡します（後方互換あり）。

## 動機

毎回 `exec workspace bash` や `up -d` などを手書きするのが面倒だったため。