### PR TITLE
コンテナでnanoを使えるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
         gnupg \
         jq \
         less \
+        nano \
         openssh-client \
         procps \
         tmux \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ uv sync --frozen --group dev
 - `copilot-cli`
 - `gh`
 - `git`
+- `nano`
 - `uv`
 - `bash`
 - `tmux`
@@ -98,4 +99,3 @@ COPILOT_CLI_VERSION=latest ./scripts/compose.sh build
 # コンテナ -> ホスト
 ./scripts/compose.sh cp workspace:/home/copilot/development/output.json ./output.json
 ```
-


### PR DESCRIPTION
## 概要
- workspace イメージに `nano` を追加
- README の同梱ツール一覧に `nano` を追記

## 検証
- `docker compose config`
- `docker compose build workspace`
- `docker compose run --rm workspace nano --version`

Closes #5