### PR TITLE
コンテナ起動時に uv の native-tls 設定を追加

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,7 +7,11 @@ copilot_instructions_source="/usr/local/share/copilot-workspace/copilot-instruct
 copilot_instructions_target="${copilot_config_dir}/copilot-instructions.md"
 bashexports_path="${HOME}/.bashexports"
 
-mkdir -p "${HOME}/.config/gh" "${copilot_config_dir}" "${development_dir}"
+mkdir -p "${HOME}/.config/gh" "${HOME}/.config/uv" "${copilot_config_dir}" "${development_dir}"
+
+if [[ ! -f "${HOME}/.config/uv/uv.toml" ]]; then
+    printf 'native-tls = true\n' > "${HOME}/.config/uv/uv.toml"
+fi
 
 if [[ -f "${copilot_instructions_source}" ]]; then
     install -m 0644 "${copilot_instructions_source}" "${copilot_instructions_target}"


### PR DESCRIPTION
## 概要

コンテナ起動時に `~/.config/uv/uv.toml` へ `native-tls = true` を自動設定するようにしました。

## 変更内容

`docker/entrypoint.sh` に以下の処理を追加:

- `~/.config/uv/` ディレクトリの作成
- `~/.config/uv/uv.toml` が存在しない場合のみ `native-tls = true` を書き込む

ファイルが既に存在する場合は上書きしないため、ユーザーがカスタム設定を持っていても安全です。

## 背景

企業ネットワーク等で OS の証明書ストアを利用する必要がある環境では、uv の `native-tls` オプションを有効にしないと TLS 接続に失敗することがあります。