### PR TITLE
zellij を workspace に追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             test "$PWD" = "/home/copilot/development"
             test "$DEVELOPMENT_DIR" = "/home/copilot/development"
             test -d "$HOME/development/worktrees"
-            command -v bash tmux gh git uv copilot
+            command -v bash tmux zellij gh git uv copilot
             alias copilot
           '
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG USERNAME=copilot
 ARG USER_UID=1000
 ARG USER_GID=1000
 ARG COPILOT_CLI_VERSION=latest
+ARG ZELLIJ_VERSION=0.44.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PATH="/home/${USERNAME}/.local/bin:${PATH}" \
@@ -32,6 +33,24 @@ RUN apt-get update \
         tmux \
         zsh \
     && rm -rf /var/lib/apt/lists/*
+
+RUN case "$(dpkg --print-architecture)" in \
+        amd64) zellij_arch='x86_64-unknown-linux-musl' ;; \
+        arm64) zellij_arch='aarch64-unknown-linux-musl' ;; \
+        *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+    && zellij_asset="zellij-${zellij_arch}.tar.gz" \
+    && zellij_sha_asset="zellij-${zellij_arch}.sha256sum" \
+    && curl -fsSLo "/tmp/${zellij_asset}" \
+        "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/${zellij_asset}" \
+    && curl -fsSLo "/tmp/${zellij_sha_asset}" \
+        "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/${zellij_sha_asset}" \
+    && cd /tmp \
+    && tar -xzf "${zellij_asset}" \
+    && expected_zellij_sha="$(awk '{print $1}' "${zellij_sha_asset}")" \
+    && echo "${expected_zellij_sha}  zellij" | sha256sum -c - \
+    && install -m 0755 zellij /usr/local/bin/zellij \
+    && rm -f "/tmp/${zellij_asset}" "/tmp/${zellij_sha_asset}" /tmp/zellij
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get update \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベースの作業用 workspace です。
 
-このリポジトリは、Copilot CLI / `gh` / `git` / `uv` / `tmux` / `zellij` などを含むコンテナを立ち上げ、ホスト側とは bind mount せずに Docker volume へ状態を閉じ込めることを目的にしています。
+このリポジトリは、Copilot CLI / `gh` / `git` / `uv` / `zellij` などを含むコンテナを立ち上げ、ホスト側とは bind mount せずに Docker volume へ状態を閉じ込めることを目的にしています。
 
 ## 前提
 
@@ -27,9 +27,6 @@ GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベ
 # root シェルに入る（apt-get で追加インストールしたいとき）
 ./scripts/compose.sh root
 
-# tmux セッションへ入る（あれば再開、なければ新規作成）
-./scripts/compose.sh tmux
-
 # zellij セッションへ入る（あれば再開、なければ新規作成）
 ./scripts/compose.sh zellij
 
@@ -42,16 +39,14 @@ GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベ
 
 BuildKit 環境によっては build 時だけ DNS 解決に失敗することがあるため、この `compose.yaml` では `build.network: host` を指定しています。これは build 中のネットワーク経路だけをホスト側へ寄せる回避策です。
 
-`./scripts/compose.sh tmux` はホスト側から `docker compose exec` とコンテナ内 `tmux new-session -A -s workspace` をまとめて実行します。作業を再開したいときは `exec` よりこちらを使うと、前回の `tmux` セッションへすぐ戻れます。
-
-`./scripts/compose.sh zellij` はコンテナ内で `workspace` セッションへの attach を試し、既存セッションがなければ同名の新規セッションを起動します。`zellij` を使いたい場合は `tmux` と同じ感覚でこちらを使えます。
+`./scripts/compose.sh zellij` はコンテナ内で `workspace` セッションへの attach を試し、既存セッションがなければ同名の新規セッションを起動します。作業を再開したいときは `exec` よりこちらを使うと、前回の `zellij` セッションへすぐ戻れます。
 
 ## コンテナ内での作業例
 
 `/home/copilot/development` は Docker volume です。ホストのリポジトリや設定ディレクトリは既定では bind mount しません。必要なものだけコンテナ内で取得してください。
 
 ```bash
-./scripts/compose.sh tmux
+./scripts/compose.sh zellij
 
 cd ~/development
 gh repo clone owner/repository
@@ -81,7 +76,7 @@ exit
 tree --version
 ```
 
-`root` は明示的に要求したときだけ使える導線です。通常作業は引き続き `copilot` ユーザーの `exec` / `tmux` を使う前提です。また、ここで行った `apt-get` の変更はコンテナの writable layer に入るため、`docker compose down` や image rebuild の扱いによっては失われる点に注意してください。
+`root` は明示的に要求したときだけ使える導線です。通常作業は引き続き `copilot` ユーザーの `exec` / `zellij` を使う前提です。また、ここで行った `apt-get` の変更はコンテナの writable layer に入るため、`docker compose down` や image rebuild の扱いによっては失われる点に注意してください。
 
 ## 含めているツール
 
@@ -92,12 +87,9 @@ tree --version
 - `nano`
 - `uv`
 - `bash`
-- `tmux`
 - `zellij`
 
 `copilot-cli` は npm パッケージ `@github/copilot` からインストールします。バージョンを固定したい場合は build 時に `COPILOT_CLI_VERSION` を渡してください。
-
-`zellij` は upstream release の Linux 向け prebuilt binary を取得して入れています。必要なら build 時に `ZELLIJ_VERSION` で固定できます。
 
 対話シェルでは、ホストの `~/.bashrc` に合わせて `BASH_ENV="$HOME/.bashexports"` を設定し、次の alias も入れています。
 
@@ -108,7 +100,7 @@ alias copilot='copilot --allow-all-tools --allow-all-paths --bash-env=on'
 ```
 
 ```bash
-COPILOT_CLI_VERSION=latest ZELLIJ_VERSION=0.44.1 ./scripts/compose.sh build
+COPILOT_CLI_VERSION=latest ./scripts/compose.sh build
 ```
 
 ## 認証情報とセキュリティ方針

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベースの作業用 workspace です。
 
-このリポジトリは、Copilot CLI / `gh` / `git` / `uv` / `tmux` などを含むコンテナを立ち上げ、ホスト側とは bind mount せずに Docker volume へ状態を閉じ込めることを目的にしています。
+このリポジトリは、Copilot CLI / `gh` / `git` / `uv` / `tmux` / `zellij` などを含むコンテナを立ち上げ、ホスト側とは bind mount せずに Docker volume へ状態を閉じ込めることを目的にしています。
 
 ## 前提
 
@@ -30,6 +30,9 @@ GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベ
 # tmux セッションへ入る（あれば再開、なければ新規作成）
 ./scripts/compose.sh tmux
 
+# zellij セッションへ入る（あれば再開、なければ新規作成）
+./scripts/compose.sh zellij
+
 # 1 回だけ Copilot CLI を使う
 ./scripts/compose.sh run --rm workspace copilot
 
@@ -40,6 +43,8 @@ GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベ
 BuildKit 環境によっては build 時だけ DNS 解決に失敗することがあるため、この `compose.yaml` では `build.network: host` を指定しています。これは build 中のネットワーク経路だけをホスト側へ寄せる回避策です。
 
 `./scripts/compose.sh tmux` はホスト側から `docker compose exec` とコンテナ内 `tmux new-session -A -s workspace` をまとめて実行します。作業を再開したいときは `exec` よりこちらを使うと、前回の `tmux` セッションへすぐ戻れます。
+
+`./scripts/compose.sh zellij` はコンテナ内で `workspace` セッションへの attach を試し、既存セッションがなければ同名の新規セッションを起動します。`zellij` を使いたい場合は `tmux` と同じ感覚でこちらを使えます。
 
 ## コンテナ内での作業例
 
@@ -88,8 +93,11 @@ tree --version
 - `uv`
 - `bash`
 - `tmux`
+- `zellij`
 
 `copilot-cli` は npm パッケージ `@github/copilot` からインストールします。バージョンを固定したい場合は build 時に `COPILOT_CLI_VERSION` を渡してください。
+
+`zellij` は upstream release の Linux 向け prebuilt binary を取得して入れています。必要なら build 時に `ZELLIJ_VERSION` で固定できます。
 
 対話シェルでは、ホストの `~/.bashrc` に合わせて `BASH_ENV="$HOME/.bashexports"` を設定し、次の alias も入れています。
 
@@ -100,7 +108,7 @@ alias copilot='copilot --allow-all-tools --allow-all-paths --bash-env=on'
 ```
 
 ```bash
-COPILOT_CLI_VERSION=latest ./scripts/compose.sh build
+COPILOT_CLI_VERSION=latest ZELLIJ_VERSION=0.44.1 ./scripts/compose.sh build
 ```
 
 ## 認証情報とセキュリティ方針

--- a/docs/adr/00002-prefer-zellij-over-tmux.md
+++ b/docs/adr/00002-prefer-zellij-over-tmux.md
@@ -19,12 +19,9 @@ workspace で継続利用する terminal multiplexer の推奨を `tmux` から 
 
 - `zellij` を workspace イメージへ含める
 - セッション再開用の compose 導線として `./scripts/compose.sh zellij` を用意する
-- `tmux` は互換性のため当面残すが、日常的な作業再開の導線としては `zellij` を優先する
 
 ## Consequences
 
 Copilot CLI の出力を扱うときに、内容のコピーや参照がしやすくなり、対話結果をベースにした作業の往復が改善される。
 
 また、`tmux` に慣れていない利用者でも、より少ない学習コストで persistent session を使い始めやすくなる。
-
-一方で、既存利用者は `tmux` と `zellij` の 2 系統がしばらく併存するため、案内文や運用上の推奨を明確に保つ必要がある。

--- a/docs/adr/00002-prefer-zellij-over-tmux.md
+++ b/docs/adr/00002-prefer-zellij-over-tmux.md
@@ -1,0 +1,30 @@
+# ADR 00002: Prefer zellij over tmux for workspace sessions
+
+- Status: accepted
+- Date: 2026-04-12
+- Supersedes: none
+- Superseded by: none
+
+## Context
+
+この workspace では、作業再開しやすい対話セッションとして `tmux` を案内してきた。
+
+しかし、Copilot CLI を `tmux` の中で使うと、出力内容をそのままコピーしづらい場面があり、会話結果やコード断片を外へ持ち出す操作の体験が悪かった。特に、Copilot CLI の出力を確認しながら必要な部分だけをコピーしたい用途では、terminal multiplexer 側の操作性が作業効率へ直接影響する。
+
+一方で `zellij` では、同様の用途でも出力をコピーできることを確認できた。また、キーバインドや画面操作も `tmux` より直感的で、初見でも扱いやすい。
+
+## Decision
+
+workspace で継続利用する terminal multiplexer の推奨を `tmux` から `zellij` へ移す。
+
+- `zellij` を workspace イメージへ含める
+- セッション再開用の compose 導線として `./scripts/compose.sh zellij` を用意する
+- `tmux` は互換性のため当面残すが、日常的な作業再開の導線としては `zellij` を優先する
+
+## Consequences
+
+Copilot CLI の出力を扱うときに、内容のコピーや参照がしやすくなり、対話結果をベースにした作業の往復が改善される。
+
+また、`tmux` に慣れていない利用者でも、より少ない学習コストで persistent session を使い始めやすくなる。
+
+一方で、既存利用者は `tmux` と `zellij` の 2 系統がしばらく併存するため、案内文や運用上の推奨を明確に保つ必要がある。

--- a/scripts/compose.sh
+++ b/scripts/compose.sh
@@ -37,6 +37,10 @@ case "${cmd}" in
     tmux)
         exec docker compose -f "${repo_root}/compose.yaml" exec workspace tmux new-session -A -s workspace
         ;;
+    zellij)
+        exec docker compose -f "${repo_root}/compose.yaml" exec workspace bash -lc \
+            'zellij attach workspace || exec zellij --session workspace'
+        ;;
     cp)
         exec docker compose -f "${repo_root}/compose.yaml" cp "$@"
         ;;
@@ -44,7 +48,7 @@ case "${cmd}" in
         exec docker compose -f "${repo_root}/compose.yaml" down "$@"
         ;;
     "")
-        echo "使い方: $(basename "$0") {build|up|exec|root|tmux|cp|down} [追加オプション...]" >&2
+        echo "使い方: $(basename "$0") {build|up|exec|root|tmux|zellij|cp|down} [追加オプション...]" >&2
         exit 1
         ;;
     *)


### PR DESCRIPTION
## 概要
- workspace イメージへ zellij を追加
- compose.sh に zellij サブコマンドを追加
- README と CI の smoke test を更新

## 補足
- Debian bookworm では zellij を apt で入れにくいため、upstream release の prebuilt binary を利用しています。
- この CLI 実行環境では docker コマンドが利用できず、docker compose config / build / run の実動確認は行えていません。