### PR TITLE
micro を workspace イメージへ追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
         less \
         libreoffice \
         fonts-noto-cjk \
+        micro \
         nano \
         openssh-client \
         procps \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベースの作業用 workspace です。
 
-このリポジトリは、Copilot CLI / `gh` / `git` / `uv` / `zellij` などを含むコンテナを立ち上げ、ホスト側とは bind mount せずに Docker volume へ状態を閉じ込めることを目的にしています。
+このリポジトリは、Copilot CLI / `gh` / `git` / `uv` / `zellij` / `micro` などを含むコンテナを立ち上げ、ホスト側とは bind mount せずに Docker volume へ状態を閉じ込めることを目的にしています。
 
 ## 前提
 
@@ -84,6 +84,7 @@ tree --version
 - `gh`
 - `git`
 - `libreoffice`
+- `micro`
 - `nano`
 - `uv`
 - `bash`


### PR DESCRIPTION
## 概要
- workspace イメージの Debian パッケージに micro を追加
- README のツール説明へ micro を追記

## 補足
- この実行環境では docker コマンドが使えず、docker compose による確認は未実施