### PR TITLE
ワークスペース名に `$USER` を含めて Docker volume 衝突を避ける

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベ
 
 このリポジトリは、Copilot CLI / `gh` / `git` / `uv` / `zellij` / `micro` などを含むコンテナを立ち上げ、ホスト側とは bind mount せずに Docker volume へ状態を閉じ込めることを目的にしています。
 
+`./scripts/compose.sh` は既定で `COMPOSE_PROJECT_NAME=copilot-workspace-$USER` 相当の project 名を使います。rootful Docker で同じホスト daemon を共有していても、ユーザーごとに volume 名が分かれるため、意図しない workspace の共有や衝突を減らせます。
+
 ## 前提
 
 ホスト側では以下を使える状態にしてください。
@@ -38,6 +40,8 @@ GitHub Copilot CLI をホストへ直接入れずに試すための、Docker ベ
 ```
 
 BuildKit 環境によっては build 時だけ DNS 解決に失敗することがあるため、この `compose.yaml` では `build.network: host` を指定しています。これは build 中のネットワーク経路だけをホスト側へ寄せる回避策です。
+
+project 名を明示的に変えたい場合は、`COMPOSE_PROJECT_NAME` を指定してください。未指定時は `./scripts/compose.sh` が `USER` をもとに安全な文字へ正規化した名前を使います。`docker compose` を直接使う場合も、同じ分離をしたければ `COMPOSE_PROJECT_NAME` を明示してください。
 
 `./scripts/compose.sh zellij` はコンテナ内で `workspace` セッションへの attach を試し、既存セッションがなければ同名の新規セッションを起動します。作業を再開したいときは `exec` よりこちらを使うと、前回の `zellij` セッションへすぐ戻れます。
 
@@ -107,14 +111,14 @@ COPILOT_CLI_VERSION=latest ./scripts/compose.sh build
 ## 認証情報とセキュリティ方針
 
 - コンテナは root ではなく `copilot` ユーザーで動かします
-- 永続化対象は Docker 管理の `copilot-workspace`, `copilot-gh-config`, `copilot-cli-config` volume に限定します
+- 永続化対象は Docker 管理の `copilot-workspace-$USER` project 配下の volume に限定します
 - ホストのリポジトリ、`~/.config/gh`、`~/.copilot`、`~/.gitconfig`、`~/.ssh` は既定ではコンテナへ持ち込みません
 - ホスト側で `gh auth login` 済みなら、helper script が token だけを取り出して起動時にコンテナ側 `gh` へ再ログインさせます
 - コンテナ起動時には `gh auth setup-git` も実行し、コンテナ内の Git 操作でも `gh` の認証設定を使えるようにします
 - copilot-cliへのログインはコンテナ内で実行する必要があります。
 - copilot-cliはaliasにより `--allow-all-tools --allow-all-paths` 付きで実行されます。URL 制限は既定の HTTPS のままですが、それでも本当にこの設定でよいかは各自の状況に合わせて慎重に判断してください。
   - ホスト側へ影響する経路は、明示的に渡した環境変数とネットワーク通信に絞られますが、リモートリポジトリの破壊や情報漏洩など悪さはやろうと思えばいくらでもできます。
-- 状態を完全に消したいときは `docker compose down -v` を実行してください
+- 状態を完全に消したいときは `./scripts/compose.sh down -v` を実行してください
 
 ホストとコンテナの間でファイルを受け渡したいときは、bind mount ではなく `docker compose cp` を使う想定です。
 

--- a/docs/adr/00003-scope-compose-project-by-user.md
+++ b/docs/adr/00003-scope-compose-project-by-user.md
@@ -1,0 +1,27 @@
+# ADR 00003: Scope compose project names by user
+
+- Status: accepted
+- Date: 2026-04-20
+- Supersedes: none
+- Superseded by: none
+
+## Context
+
+この workspace は、bind mount を避けて Docker volume に状態を閉じ込める前提で設計している。
+
+しかし rootful Docker では、同じホスト上の利用者が同一 daemon を共有する。compose project 名がユーザー非依存のままだと、同じリポジトリ名から起動した別ユーザー同士で volume 名が衝突し、意図せず同じ workspace 状態を共有してしまう。
+
+これは認証情報や開発中ファイルの混線につながりやすく、事故的な状態破壊や情報混入のリスクがある。
+
+## Decision
+
+compose project 名の既定値にホスト側の `USER` を含める。
+
+- `scripts/compose.sh` は `COMPOSE_PROJECT_NAME` 未指定時に `USER` を正規化して `copilot-workspace-$USER` 形式の project 名を設定する
+- 明示的な `COMPOSE_PROJECT_NAME` 指定は引き続き優先する
+
+## Consequences
+
+同じホスト daemon を共有する環境でも、ユーザーごとに volume 名が分離され、workspace の accidental な共有を起こしにくくなる。
+
+一方で、既存の非ユーザー分離 project 名で作成済みの volume は、そのままでは新しい既定 project から参照されない。既存状態を引き継ぎたい場合は、従来の project 名を `COMPOSE_PROJECT_NAME` で明示するか、必要なデータを移行する必要がある。

--- a/scripts/compose.sh
+++ b/scripts/compose.sh
@@ -4,6 +4,21 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
 
+if [[ -z "${COMPOSE_PROJECT_NAME:-}" ]]; then
+    workspace_owner_raw="${USER:-default}"
+    workspace_owner="$(
+        printf '%s' "${workspace_owner_raw}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'
+    )"
+
+    if [[ -z "${workspace_owner}" ]]; then
+        workspace_owner="default"
+    fi
+
+    export COMPOSE_PROJECT_NAME="copilot-workspace-${workspace_owner}"
+fi
+
 if gh auth status >/dev/null 2>&1; then
     export COPILOT_HOST_GH_TOKEN
     COPILOT_HOST_GH_TOKEN="$(gh auth token)"


### PR DESCRIPTION
## 概要
- `scripts/compose.sh` で `COMPOSE_PROJECT_NAME` 未指定時に `copilot-workspace-$USER` を既定値として設定
- `USER` を Docker Compose project 名向けに正規化して、同一 host daemon 上での accidental な volume 共有を減らす
- README と ADR を更新して、新しい既定動作と移行上の注意点を追記

## 補足
- この実行環境には `docker` コマンドが無いため、`docker compose config/build/run` の実行確認は未実施